### PR TITLE
consolidate case statement in the print_automation_objects method

### DIFF
--- a/object_walker.rb
+++ b/object_walker.rb
@@ -56,14 +56,10 @@ end
 
 def print_automation_objects(indent_level, hierarchy)
   case hierarchy.position
-  when 'root'
-    print_line(indent_level, "#{hierarchy.obj_name}  ($evm.root)")
-  when 'parent'
-    print_line(indent_level, "#{hierarchy.obj_name}  ($evm.parent)")
-  when 'object'
-    print_line(indent_level, "#{hierarchy.obj_name}  ($evm.object)")
-  else
-    print_line(indent_level, "#{hierarchy.obj_name}")
+  when 'root' then print_line(indent_level, "#{hierarchy.obj_name}  ($evm.root)")
+  when 'parent' then print_line(indent_level, "#{hierarchy.obj_name}  ($evm.parent)")
+  when 'object' then print_line(indent_level, "#{hierarchy.obj_name}  ($evm.object)")
+  else print_line(indent_level, "#{hierarchy.obj_name}")
   end
   indent_level += 1
   hierarchy.children.each do |child|


### PR DESCRIPTION
This is a simple change to consolidate the case statement in the print_automation_objects method. It doesn't change functionality, just saves some lines. It moves it away from the format:
```
case people
when "Peter"
  puts "author"
when "Nick"
  puts "Brit"
when "Loic"
  puts "BU"
else
  puts "I don't know!"
end
```
Into the consolidated format:
```
case people
  when "Peter" then puts "Author"
  when "Nick" then puts "Brit"
  when "Loic" then puts "BU"
  else puts "I don't know!"
end
```
