### PR TITLE
install object walker into %_bindir

### DIFF
--- a/object_walker_reader.spec
+++ b/object_walker_reader.spec
@@ -22,13 +22,13 @@ object_walker_reader extracts the output from object_walker and writes it out in
 
 %install
 rm -rf %{buildroot}
-mkdir -p %{buildroot}/root
-install -m 0755 %{name}.rb %{buildroot}/root/%{name}.rb
+mkdir -p %{buildroot}/%_bindir
+install -m 0755 %{name}.rb %{buildroot}/%_bindir/%{name}
 
 %files
 
 %defattr(-,root,root)
-%attr(0755,root,root) /root/object_walker_reader.rb
+%attr(0755,root,root) %_bindir/object_walker_reader
 
 %doc
 


### PR DESCRIPTION
install the binary not into /root, but into %_bindir which usually points to /usr/bin

Following RPM best practices: https://docs.fedoraproject.org/en-US/packaging-guidelines/RPMMacros/